### PR TITLE
quick fix for checking updates on deploy

### DIFF
--- a/src/controls/deploy.ts
+++ b/src/controls/deploy.ts
@@ -28,15 +28,10 @@ async function getLatestVersion(packageName: string): Promise<string> {
 
 async function checkVersionAndWarnUser() {
   try {
-    // Get the globally installed version
-    const globalVersion = execSync("npm list -g forge-ml --depth=0")
-      .toString()
-      .match(/forge-ml@([\d.]+)/)?.[1];
-
-    if (!globalVersion) {
-      console.log(cWrap.fm("forge-ml is not installed globally."));
-      return;
-    }
+    // Get the globally installed version using forge --version
+    const globalVersion = execSync("forge --version", {
+      encoding: "utf8",
+    }).trim();
 
     const latestVersion = await getLatestVersion("forge-ml");
 
@@ -48,7 +43,11 @@ async function checkVersionAndWarnUser() {
       );
     }
   } catch (e) {
-    console.log(cWrap.fr("Error checking for updates"));
+    console.log(
+      cWrap.fr(
+        "Error checking for updates: forge-ml might not be installed globally."
+      )
+    );
   }
 }
 

--- a/src/controls/deploy.ts
+++ b/src/controls/deploy.ts
@@ -29,7 +29,7 @@ async function getLatestVersion(packageName: string): Promise<string> {
 async function checkVersionAndWarnUser() {
   try {
     // Get the globally installed version using forge --version
-    const globalVersion = execSync("forge --version", {
+    const globalVersion = execSync(`${cfg.bin} --version`, {
       encoding: "utf8",
     }).trim();
 

--- a/src/controls/deploy.ts
+++ b/src/controls/deploy.ts
@@ -37,7 +37,7 @@ async function checkVersionAndWarnUser() {
     if (globalVersion !== latestVersion) {
       console.log(
         cWrap.fr(
-          `You are using an outdated version of forge-ml (${globalVersion}). Please update to the latest version: ${latestVersion} by running:`
+          `You are using an outdated version of forge-ml (${globalVersion}). Please update to the latest version ${latestVersion}, by running:`
         ) +
           cWrap.fy("\nnpm install -g forge-ml@latest ") +
           "or " +

--- a/src/controls/deploy.ts
+++ b/src/controls/deploy.ts
@@ -34,12 +34,14 @@ async function checkVersionAndWarnUser() {
     }).trim();
 
     const latestVersion = await getLatestVersion("forge-ml");
-
     if (globalVersion !== latestVersion) {
       console.log(
-        cWrap.fm(
+        cWrap.fr(
           `You are using an outdated version of forge-ml (${globalVersion}). Please update to the latest version: ${latestVersion} by running:`
-        ) + cWrap.fg("\nnpm install -g forge-ml@latest")
+        ) +
+          cWrap.fy("\nnpm install -g forge-ml@latest ") +
+          "or " +
+          cWrap.fy("forge update\n")
       );
     }
   } catch (e) {


### PR DESCRIPTION
- previously deploy checked a project package.json for current forge version instead of checking for the global version

- this update uses 
```bash
forge --version
```
to check for updates

If we ever move off of the cli tool this could become outdated - consider using npm -g list forge-ml?

THIS NEEDS TESTING